### PR TITLE
RSDK-5103 Add module auto-registration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ micro-rdk = {git = "https://github.com/viamrobotics/micro-rdk.git", features = [
 
 [build-dependencies]
 anyhow = "1"
+cargo_metadata = "0.18.1"
 const-gen = "1.3.0"
 embuild = "0.29"
 gethostname = "0.4.1"


### PR DESCRIPTION
This is the robot template side of a scheme to support module auto-loading. At `build.rs` time we iterate the `Cargo.toml` `dependencies` of the project, and identify those which have a populated `package.metadata.com.viam` section with `module=true`, e.g.:

```
[package.metadata.com.viam]
module = true
```

Given this list of module names, we emit a `modules.rs` which contains an invocation of the `generate_register_modules` macro with the sequence of module names as the argument.

That macro is defined in the generated `main.rs` to simply call a well-known entrypoint called `register_models` for each module, passing the `ComponentRegistry` instance. The implementation of `register_models` in each module should in turn call the correct `ComponentRegistry::register_thing` function for each component it wants to inject into the micro-rdk.

With this machinery in place, a project that wishes to incorporate a module would:
1) Generate a new robot with `cargo generate --git https://github.com/viamrobotics/micro-rdk-robot-template.git`
2) Add each module to the `dependencies` section of the generated `Cargo.toml`.
3) Compile and flash.

Next steps would be to create a new `cargo generate` template at `viamrobotics/micro-rdk-module-template.git` that would generate a library+test crate with the well-known entry point declared and the `package.metadata` annotation already applied.
