### PR TITLE
RSDK-5397 Use forks from viamrobotics not npmenard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ authors = ["{{authors}}"]
 resolver = "2"
 
 [patch.crates-io]
-esp-idf-sys = {git = "https://github.com/npmenard/esp-idf-sys.git"}
+esp-idf-sys = {git = "https://github.com/viamrobotics/esp-idf-sys.git"}
 polling = { git = "https://github.com/esp-rs-compat/polling" }
 smol = { git = "https://github.com/esp-rs-compat/smol" }
-socket2 = { git = "https://github.com/npmenard/socket2.git" }
-async-io = {git = "https://github.com/npmenard/async-io.git"}
+socket2 = { git = "https://github.com/viamrobotics/socket2.git" }
+async-io = {git = "https://github.com/viamrobotics/async-io.git"}
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
I have not run `cargo update` as part of this PR since it won't (yet) work until the repos are transferred.